### PR TITLE
Fix dir case

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.6.0/miniku
 
 ## Install and start SpiniKube
 ```
-git clone https://github.com/kenzanlabs/spinikube.git && cd SpiniKube
+git clone https://github.com/kenzanlabs/spinikube.git && cd spinikube
 python setup.py
 ```
 


### PR DESCRIPTION
Before that I was getting this :

```
git clone https://github.com/kenzanlabs/spinikube.git && cd SpiniKube
Cloning into 'spinikube'...
remote: Counting objects: 141, done.
remote: Total 141 (delta 0), reused 0 (delta 0), pack-reused 141
Receiving objects: 100% (141/141), 2.11 MiB | 843.00 KiB/s, done.
Resolving deltas: 100% (49/49), done.
Checking connectivity... done.
cd: no such file or directory: SpiniKube
```